### PR TITLE
Subscribe to state on CBScheduler

### DIFF
--- a/ReactiveBLE/RBTCentralManager.m
+++ b/ReactiveBLE/RBTCentralManager.m
@@ -50,9 +50,9 @@
 - (RACSignal *)stateSignal
 {
 	@weakify(self);
-	return [[[[[[RACSignal defer:^{
+	return [[[[[RACSignal defer:^{
 		@strongify(self);
-		return [RACSignal return:self.manager];
+		return [[RACSignal return:self.manager] deliverOn:self.CBScheduler];
 	}]
 	concat:[[self rac_signalForSelector:@selector(centralManagerDidUpdateState:) fromProtocol:@protocol(CBCentralManagerDelegate)]
 		reduceEach:^(CBCentralManager *manager) {
@@ -61,7 +61,6 @@
 	map:^(CBCentralManager *manager) {
 		return @(manager.state);
 	}]
-	subscribeOn:self.CBScheduler]
 	takeUntil:self.rac_willDeallocSignal]
 	setNameWithFormat:@"<%@:%p> -stateSignal", self.class, self];
 }

--- a/ReactiveBLE/RBTCentralManager.m
+++ b/ReactiveBLE/RBTCentralManager.m
@@ -50,7 +50,7 @@
 - (RACSignal *)stateSignal
 {
 	@weakify(self);
-	return [[[[[RACSignal defer:^{
+	return [[[[[[RACSignal defer:^{
 		@strongify(self);
 		return [RACSignal return:self.manager];
 	}]
@@ -61,6 +61,7 @@
 	map:^(CBCentralManager *manager) {
 		return @(manager.state);
 	}]
+	subscribeOn:self.CBScheduler]
 	takeUntil:self.rac_willDeallocSignal]
 	setNameWithFormat:@"<%@:%p> -stateSignal", self.class, self];
 }


### PR DESCRIPTION
I'm not 100% sure on this, but I think the state subscription should be handled on the `CBScheduler` (like all of the other delegate method subscriptions) because delegate method calls should be processed in a serial order.
